### PR TITLE
Added information from https://join.lemmy.ml/do… … dfd438a …cs/en/contributing/websocket_http_api.html

### DIFF
--- a/static/scripts/asyncapi.yaml
+++ b/static/scripts/asyncapi.yaml
@@ -10,60 +10,44 @@ info:
     [**Lemmy**](https://github.com/LemmyNet/lemmy) is a decentralized alternative to proprietary link aggregators such as Reddit.
     #### More information...
     - [Install your own server](https://join.lemmy.ml/docs/en/administration/administration.html)
-    - [Lemmy data types](https://join.lemmy.ml/docs/en/contributing/websocket_http_api.html#data-types)
-    - [Images](https://join.lemmy.ml/docs/en/contributing/websocket_http_api.html#images)
-    - [RSS/Atom feeds](https://join.lemmy.ml/docs/en/contributing/websocket_http_api.html#rss--atom-feeds)
-    - [Rate limiting](https://join.lemmy.ml/docs/en/contributing/websocket_http_api.html#default-rate-limits)
+    - [API reference](link_here)
     ### How to use this WebSocket API document
     You can either use it to:
-    - **Interactively browse the WebSocket API.** Browse the *Channels*, check out the responses and examples (tailor the *PUBLISH* requests to suit with your favorite WebSocket client - such as [websocat](https://github.com/vi/websocat)).
+    - **Interactively browse the WebSocket API.** Browse the *Channels*, check out the responses and examples (tailor the *PUBLISH* requests to suit with your favorite WebSocket client).
     For testing purposes, either [set up your own server](https://join.lemmy.ml/docs/en/administration/administration.html) or use the Enterprise server (*ws://enterprise.lemmy.ml/api/v2/ws*)
     - **[Open and save](asyncapi.yaml) this specification file** and use it with the various [AsyncAPI tools](https://www.asyncapi.com/docs/community/tooling) (perhaps to generate code or documentation).
-    #### Structure of this document
+
+    Connect to <code>ws://***host***/api/v2/ws</code> to get started. If the server supports secure connections, you can use `wss://**server**/api/v1/ws`.
+    #### Testing with websocat
+
+    For example a simple test using [websocat](https://github.com/vi/websocat) might be:
+
+    `websocat ws://127.0.0.1:8536/api/v2/ws -nt`
+
+    A simple test command:
+
+    `{"op": "ListCategories", "data": {}}`
+
+    #### Testing with the [WebSocket JavaScript API](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API)
+
+    ```javascript
+    var ws = new WebSocket("ws://" + host + "/api/v2/ws");
+    ws.onopen = function () {
+      console.log("Connection succeed!");
+      ws.send(JSON.stringify({
+        op: "ListCategories",
+        data: {}
+      }));
+    };
+    ```
+
+    ### Structure of this document
     - **Channels** - Documents the requests (marked with the PUBLISH button) and responses (marked with SUBSCRIBE) for each endpoint (*channel*)
     - **Servers** - Lists some publicly-accessible test servers
-    - **Messages** - A summary of the requests and responses (a duplication of the information in **=Channels*)
+    - **Messages** - A summary of the requests and responses (a duplication of the information in **Channels**)
     - **Schemas** - An alphabetical list of the most commonly accessed data structures in the API.
     ### The HTTP API
-    Lemmy also has an HTTP API which is almost identical to the WebSocket API:
-    - WebSocket API needs `let send = { op: userOperation[op], data: form}` as shown below
-    - HTTP API requires the form (data) at the top level and an HTTP operation (GET, PUT or POST) and endpoint.
-    For example: `POST {username_or_email: X, password: X}`. Endpoints are at `http(s)://host/api/v2/endpoint`. *All request and response strings are in [JSON format](https://www.json.org/json-en.html).*
-    
-
-    For more information,  see the [http.ts](https://github.com/LemmyNet/lemmy-js-client/blob/main/src/http.ts) file.
-    #### Example (TypeScript)
-
-    ```ts
-      async editComment(form: EditComment): Promise<CommentResponse> {
-      return this.wrapper(HttpType.Put, '/comment', form);
-      }
-    ```
-
-    | Type | URL | Body type | Return type |
-    | --- | --- | --- | --- |
-    | `PUT` | `/comment` | `EditComment` | `CommentResponse` |
-
-    #### Examples (Curl)
-    **GET example**
-
-    ```
-    curl "http://localhost:8536/api/v2/community/list?sort=Hot"`
-    ```
-
-    **POST example**
-
-    ```
-    curl -i -H \
-    "Content-Type: application/json" \
-    -X POST \
-    -d '{
-      "comment_id": 374,
-      "score": 1,
-      "auth": eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MiwiaXNzIjoidGVzdC5sZW1teS5tbCJ9.P77RX_kpz1a_geY5eCp29sl_5mAm-k27Cwnk8JcIZJk
-    }' \
-    http://localhost:8536/api/v2/comment/like
-    ```
+    Lemmy also has an [HTTP API](link_here) which is almost identical to the WebSocket API; however, this WebSocket API is the primary source since it also details the specifics of HTTP API calls.
 
   license: 
     name: AGPL
@@ -1750,9 +1734,7 @@ components:
               - password
             properties:
               username_or_email:
-                type: string
-                description: 'Username or registered email'
-                example: 'lemmy'
+                $ref: '#/components/schemas/username_or_email'
               password:
                 $ref: '#/components/schemas/password'
     loginResponse:
@@ -5665,6 +5647,10 @@ components:
           $ref: '#/components/schemas/counts'
         user:
             $ref: '#/components/schemas/user'
+    'username_or_email':
+      type: string
+      description: 'Username or registered email'
+      example: 'lemmy'
     'users_active_day':
       desciption: Number of 'active' users in the previous 24 hours
       type: number

--- a/static/scripts/asyncapi.yaml
+++ b/static/scripts/asyncapi.yaml
@@ -10,7 +10,6 @@ info:
     [**Lemmy**](https://github.com/LemmyNet/lemmy) is a decentralized alternative to proprietary link aggregators such as Reddit.
     #### More information...
     - [Install your own server](https://join.lemmy.ml/docs/en/administration/administration.html)
-    - [WebSocket](https://join.lemmy.ml/docs/en/contributing/websocket_http_api.html#websocket)
     - [Lemmy data types](https://join.lemmy.ml/docs/en/contributing/websocket_http_api.html#data-types)
     - [Images](https://join.lemmy.ml/docs/en/contributing/websocket_http_api.html#images)
     - [RSS/Atom feeds](https://join.lemmy.ml/docs/en/contributing/websocket_http_api.html#rss--atom-feeds)
@@ -509,7 +508,7 @@ channels:
     publish:
       summary: UserJoin (request)
       description: |-
-        Forthcoming...
+        Join to receive WebSocket replies, private messages and so on for this user.
 
         #### HTTP API - operation and endpoint.
 
@@ -521,7 +520,7 @@ channels:
         $ref: '#/components/messages/userJoinRequest'
     subscribe:
       summary: UserJoin (response)
-      description: Forthcoming...
+      description: Verification that you will receive these WebSocket messages
       operationId: userJoinResponseMessage
       tags:
         - name: User, authentication and admin
@@ -1052,7 +1051,7 @@ channels:
     publish:
       summary: CommunityJoin (request)
       description: |-
-        Forthcoming...
+        Join to receive WebSocket messages for this community's posts.
 
         #### HTTP API - operation and endpoint.
 
@@ -1064,7 +1063,7 @@ channels:
         $ref: '#/components/messages/communityJoinRequest'
     subscribe:
       summary: CommunityJoin (response)
-      description: Forthcoming...
+      description: Verification that you will receive these WebSocket messages
       operationId: CommunityJoinResponseMessage
       tags:
         - name: Community
@@ -1076,7 +1075,7 @@ channels:
     publish:
       summary: ModJoin (request)
       description: |-
-        Forthcoming...
+        Join to receive WebSocket messages for community moderator updates such as reports.
 
         #### HTTP API - operation and endpoint.
 
@@ -1088,7 +1087,7 @@ channels:
         $ref: '#/components/messages/modJoinRequest'
     subscribe:
       summary: ModJoin (response)
-      description: Forthcoming...
+      description: Verification that you will receive these WebSocket messages
       operationId: modJoinResponseMessage
       tags:
         - name: Community
@@ -1352,7 +1351,7 @@ channels:
     publish:
       summary: PostJoin (request)
       description: |-
-        Forthcoming...
+        Join to receive WebSocket messages for this post's comments.
         
         #### HTTP API - operation and endpoint.
         
@@ -1364,7 +1363,7 @@ channels:
         $ref: '#/components/messages/postJoinRequest'
     subscribe:
       summary: PostJoin (response)
-      description: Forthcoming...
+      description: Verification that you will receive these WebSocket messages
       operationId: postJoinResponseMessage
       tags:
         - name: Post
@@ -2448,7 +2447,7 @@ components:
           data:
             $ref: '#/components/schemas/ban_view'
     userJoinRequest:
-      name: Forthcoming...
+      name: Request to receive WebSocket messages for this user.
       payload:
         type: object
         required:
@@ -2467,7 +2466,7 @@ components:
               auth:
                 $ref: '#/components/schemas/authStringSchema'
     userJoinResponse:
-      name: Forthcoming...
+      name: Verification that you will receive these WebSocket messages
       payload:
         type: object
         properties:
@@ -3474,7 +3473,7 @@ components:
               community_view:
                 $ref: '#/components/schemas/community_view'
     communityJoinRequest:
-      name: Forthcoming...
+      name: Request to receive WebSocket messages for this community's posts
       payload:
         type: object
         required:
@@ -3493,7 +3492,7 @@ components:
               community_id:
                 $ref: '#/components/schemas/community_id'
     communityJoinResponse:
-      name: Forthcoming...
+      name: Verification that you will receive these WebSocket messages
       payload:
         type: object
         properties:
@@ -3506,7 +3505,7 @@ components:
               joined:
                 $ref: '#/components/schemas/joined'
     modJoinRequest:
-      name: Forthcoming...
+      name: Request to receive WebSocket messages for community moderator updates such as reports.
       payload:
         type: object
         required:
@@ -3525,7 +3524,7 @@ components:
               community_id:
                 $ref: '#/components/schemas/community_id'
     modJoinResponse:
-      name: Forthcoming...
+      name: Verification that you will receive these WebSocket messages
       payload:
         type: object
         properties:
@@ -3938,7 +3937,7 @@ components:
               post_view:
                 $ref: '#/components/schemas/post_view'
     postJoinRequest:
-      name: Forthcoming...
+      name: Request to receive WebSocket messages for this post's comments
       payload:
         type: object
         required:
@@ -3957,7 +3956,7 @@ components:
               post_id:
                 $ref: '#/components/schemas/post_id'
     postJoinResponse:
-      name: Forthcoming...
+      name: Verification that you will receive these WebSocket messages
       payload:
         type: object
         properties:

--- a/static/scripts/asyncapi.yaml
+++ b/static/scripts/asyncapi.yaml
@@ -7,20 +7,66 @@ info:
     url: https://mastodon.social/@LemmyDev
   description: |-
     ### About Lemmy
-    [**Lemmy**](https://github.com/LemmyNet/lemmy) is a decentralized alternative to widely-used proprietary link aggregators like Reddit.
-
+    [**Lemmy**](https://github.com/LemmyNet/lemmy) is a decentralized alternative to proprietary link aggregators such as Reddit.
+    #### More information...
+    - [Install your own server](https://join.lemmy.ml/docs/en/administration/administration.html)
+    - [WebSocket](https://join.lemmy.ml/docs/en/contributing/websocket_http_api.html#websocket)
+    - [Lemmy data types](https://join.lemmy.ml/docs/en/contributing/websocket_http_api.html#data-types)
+    - [Images](https://join.lemmy.ml/docs/en/contributing/websocket_http_api.html#images)
+    - [RSS/Atom feeds](https://join.lemmy.ml/docs/en/contributing/websocket_http_api.html#rss--atom-feeds)
+    - [Rate limiting](https://join.lemmy.ml/docs/en/contributing/websocket_http_api.html#default-rate-limits)
     ### How to use this WebSocket API document
-
     You can either use it to:
-    - **Interactively browse the WebSocket API.** Browse the *Channels*, check out the responses and examples (tailor the *PUBLISH* requests to suit with your favorite WebSocket API client). For testing purposes, either [set up your own server](https://lemmy.ml/docs/en/administration/administration.html) or use the Enterprise server (*ws://enterprise.lemmy.ml/api/v2/ws*)
+    - **Interactively browse the WebSocket API.** Browse the *Channels*, check out the responses and examples (tailor the *PUBLISH* requests to suit with your favorite WebSocket client - such as [websocat](https://github.com/vi/websocat)).
+    For testing purposes, either [set up your own server](https://join.lemmy.ml/docs/en/administration/administration.html) or use the Enterprise server (*ws://enterprise.lemmy.ml/api/v2/ws*)
     - **[Open and save](asyncapi.yaml) this specification file** and use it with the various [AsyncAPI tools](https://www.asyncapi.com/docs/community/tooling) (perhaps to generate code or documentation).
-
+    #### Structure of this document
+    - **Channels** - Documents the requests (marked with the PUBLISH button) and responses (marked with SUBSCRIBE) for each endpoint (*channel*)
+    - **Servers** - Lists some publicly-accessible test servers
+    - **Messages** - A summary of the requests and responses (a duplication of the information in **=Channels*)
+    - **Schemas** - An alphabetical list of the most commonly accessed data structures in the API.
     ### The HTTP API
-
-    Lemmy also has an HTTP API. The WebSocket and HTTP API are almost identical:
+    Lemmy also has an HTTP API which is almost identical to the WebSocket API:
     - WebSocket API needs `let send = { op: userOperation[op], data: form}` as shown below
-    - HTTP API requires the form at the top level and an HTTP operation (GET, PUT or POST) and endpoint. For example: `PUT /comment`. For more information,  see [http.ts](https://github.com/LemmyNet/lemmy-js-client/blob/main/src/http.ts)
-  license:
+    - HTTP API requires the form (data) at the top level and an HTTP operation (GET, PUT or POST) and endpoint.
+    For example: `POST {username_or_email: X, password: X}`. Endpoints are at `http(s)://host/api/v2/endpoint`. *All request and response strings are in [JSON format](https://www.json.org/json-en.html).*
+    
+
+    For more information,  see the [http.ts](https://github.com/LemmyNet/lemmy-js-client/blob/main/src/http.ts) file.
+    #### Example (TypeScript)
+
+    ```ts
+      async editComment(form: EditComment): Promise<CommentResponse> {
+      return this.wrapper(HttpType.Put, '/comment', form);
+      }
+    ```
+
+    | Type | URL | Body type | Return type |
+    | --- | --- | --- | --- |
+    | `PUT` | `/comment` | `EditComment` | `CommentResponse` |
+
+    #### Examples (Curl)
+    **GET example**
+
+    ```
+    curl "http://localhost:8536/api/v2/community/list?sort=Hot"`
+    ```
+
+    **POST example**
+
+    ```
+    curl -i -H \
+    "Content-Type: application/json" \
+    -X POST \
+    -d '{
+      "comment_id": 374,
+      "score": 1,
+      "auth": eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MiwiaXNzIjoidGVzdC5sZW1teS5tbCJ9.P77RX_kpz1a_geY5eCp29sl_5mAm-k27Cwnk8JcIZJk
+    }' \
+    http://localhost:8536/api/v2/comment/like
+    ```
+
+  license: 
     name: AGPL
     url: 'https://www.gnu.org/licenses/agpl-3.0.en.html'
 servers:
@@ -36,10 +82,6 @@ servers:
     url: voyager.lemmy.ml/api/v2/ws
     protocol: WebSocket
     description: Voyager test server
-  local:
-    url: localhost:1235/api/v2/ws
-    protocol: WebSocket
-    description: Local Docker container
 externalDocs:
   description: Lemmy documentation
   url: 'https://lemmy.ml/docs/index.html'
@@ -4854,7 +4896,9 @@ components:
     'deleted':
       type: boolean
       description: |-
-        Set to *true* if this community, post, comment, message or user account should be or has been deleted. Unlike *removal*, deletion is not permanent. Deleted items can be recovered
+        Set to *true* if this community, post, comment, message or user account should be, or has been, deleted. Unlike *removal*, deletion is not permanent. Deleted items *can* be recovered.
+
+        You can undo a delete yourself by setting this value to *false*.
       example: false
     'description':
       type: string
@@ -4922,7 +4966,9 @@ components:
         - *false* if this is a federated user
     'locked':
       description: |-
-        Set to *true* if the post is already, or should be, locked. A locked post cannot receive comments
+        Set to *true* if the post is already, or should be, locked. A locked post cannot receive comments.
+
+        You can undo a lock yourself by setting this value to *false*.
       type: boolean
       example: true
     'limit':
@@ -5227,7 +5273,10 @@ components:
       example: '2021-01-21T16:42:39.897148'
     'read':
       type: boolean
-      description: Set to *true* if this post, comment or message has been read (or should be marked as being read)
+      description: |-
+        Set to *true* if this post, comment or message has been read (or should be marked as being read).
+
+        If you have marked something as being read, you can undo this yourself by setting this value to *false*.
       example: false
     'reason':
       description: Give a reason for the action. Why was this post deleted? Why was this user banned?
@@ -5247,8 +5296,8 @@ components:
       type: boolean
       description: |-
         Set to *true* if this community, post, comment or message should be or has been *permanently* deleted.
-        
-        Only admin and moderator roles can do this.
+
+        An admin or moderator can undo a removal by setting this value to *false*.
       example: false
     'replies':
       type: array


### PR DESCRIPTION
Not all of it seemed entirely pertinent to the aims of an 'API quick start' which is what an API spec is (in documentation terms).

I have added references to the omitted parts (plus the installation guide).

I can edit websocket_http_api.md to remove things that sit in the AsyncAPI file if you wish. It could also do with a prominent link to the AsyncAPI file but not sure how your build process will render that...