### PR TITLE
Added asynchronous responses to Join requests

### DIFF
--- a/src/assets/scripts/asyncapi.yaml
+++ b/src/assets/scripts/asyncapi.yaml
@@ -56,6 +56,11 @@ info:
     - **Messages** - A summary of the requests and responses (a duplication of the information in **Channels**)
     - **Schemas** - An alphabetical list of the most commonly accessed data structures in the API.
 
+    ### The 'join' channels - CommunityJoin, ModJoin, PostJoin, UserJoin
+
+    Most API responses generate an immediate and direct (synchronous) response to to the preceding API request: one of an error or a success response. 
+    However, for the ‘join’ requests (**CommunityJoin**, **ModJoin**, **PostJoin** and **UserJoin**), you can also receive any of several ‘as it happens’ (asynchronous) responses.
+
     ### The HTTP API
 
     Lemmy also has an [HTTP API](https://join.lemmy.ml/docs/en/contributing/http_api.html) which is almost identical to the WebSocket API; however, this WebSocket API is the primary source since it also details the specifics of HTTP API calls.
@@ -174,6 +179,8 @@ channels:
       description: |-
         - Use the `username` field to return details about a local user
         - Use the `person_id` field to return details about a federated user.
+
+        `community_id` restricts posts and comments in the response to this community.
 
         #### HTTP API - operation and endpoint.
 
@@ -532,9 +539,13 @@ channels:
       tags:
         - name: User, authentication and admin
       message:
-        oneOf:
+        anyOf:
           - $ref: "#/components/messages/userJoinResponse"
           - $ref: "#/components/messages/errorResponse"
+          - $ref: "#/components/messages/createCommentLikeResponse"
+          - $ref: "#/components/messages/createCommentResponse"
+          - $ref: "#/components/messages/createPrivateMessageResponse"
+          - $ref: "#/components/messages/deleteCommentResponse"
   GetReportCount:
     publish:
       summary: GetReportCount (request)
@@ -1051,9 +1062,13 @@ channels:
       tags:
         - name: Community
       message:
-        oneOf:
+        anyOf:
           - $ref: "#/components/messages/communityJoinResponse"
           - $ref: "#/components/messages/errorResponse"
+          - $ref: "#/components/messages/createPostResponse"
+          - $ref: "#/components/messages/editPostResponse"
+          - $ref: "#/components/messages/deletePostResponse"
+          - $ref: "#/components/messages/createPostLikeResponse"
   ModJoin:
     publish:
       summary: ModJoin (request)
@@ -1351,9 +1366,13 @@ channels:
       tags:
         - name: Post
       message:
-        oneOf:
+        anyOf:
           - $ref: "#/components/messages/postJoinResponse"
           - $ref: "#/components/messages/errorResponse"
+          - $ref: "#/components/messages/createCommentResponse"
+          - $ref: "#/components/messages/editCommentResponse"
+          - $ref: "#/components/messages/deleteCommentResponse"
+          - $ref: "#/components/messages/createPostLikeResponse"
   CreatePostReport:
     publish:
       summary: CreatePostReport (request)


### PR DESCRIPTION
Most API responses generate an immediate and direct (synchronous) response to to the preceding API request: one of an error or a success response. However, for the ‘join’ requests (CommunityJoin, ModJoin, PostJoin, UserJoin), you can also receive any of several ‘as it happens’ (asynchronous) responses.

I’ve updated the API to catch some of these potential responses. Please extend to add any others:

- CommunityJoin - allowed CreatePost, EditPost, DeletePost, CreatePostLike responses
- PostJoin - allowed CreateComment, EditComment, DeleteComment, CreatePostLike responses
- UserJoin - allowed CreateCommentLike, CreateComment, CreatePrivateMessage, DeleteComment

ModJoin needs filling in, Feel free to add any others that apply to the others, too. For instance RemovePost and the like

In all cases, this requires changing the ‘message’ section for each response from ‘oneOf’ to ‘anyOf’ 

I also added the initial paragraph from here to the introductory section of the AsycnAPI file.