### PR TITLE
Also track external link clicks

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -111,7 +111,7 @@ server.get("/*", async (req, res) => {
            <body ${helmet.bodyAttributes.toString()}>
              <div id='root'>${root}</div>
              <script defer src='/static/js/client.js'></script>
-             <script defer data-domain="join-lemmy.org" src="https://plausible.lemmy.ml/js/plausible.js"></script>
+             <script defer data-domain="join-lemmy.org" src="https://plausible.lemmy.ml/js/plausible.outbound-links.js"></script>
            </body>
          </html>
 `);


### PR DESCRIPTION
https://plausible.io/docs/outbound-link-click-tracking

For tracking visits to /docs, and to Lemmy instances.