### PR TITLE
Show monthly active users in instance totals

### DIFF
--- a/src/shared/components/instances.tsx
+++ b/src/shared/components/instances.tsx
@@ -53,7 +53,7 @@ export class Instances extends Component<any, any> {
       <i>
         {i18n.t("instance_totals", {
           instances: numToSI(instance_stats.stats.crawled_instances),
-          users: numToSI(instance_stats.stats.total_users),
+          users: numToSI(instance_stats.stats.users_active_month),
         })}
       </i>
     );


### PR DESCRIPTION
I think this makes more sense, because we also show monthly users for each instance.

https://github.com/LemmyNet/joinlemmy-translations/pull/4