### PR TITLE
Use specific lemmy js client version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "lemmy-js-client"]
 	path = lemmy-js-client
 	url = https://github.com/LemmyNet/lemmy-js-client
-	branch = main
+	branch = release/v0.17
 [submodule "lemmy-stats-crawler"]
 	path = lemmy-stats-crawler
 	url = https://github.com/LemmyNet/lemmy-stats-crawler.git

--- a/update_submodules.sh
+++ b/update_submodules.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Note:
+# To update lemmy-js-client, first change its branch in your .gitmodules
+
 pushd ../joinlemmy-translations
 git fetch weblate
 git merge weblate/main


### PR DESCRIPTION
The docs now use a hardcoded chose branch for the lemmy-js-client. This should avoid people using API abilities that haven't been released yet, simply because they've been merged into the main branch.