### PR TITLE
Fix <title> not being translated

### DIFF
--- a/src/shared/components/apps.tsx
+++ b/src/shared/components/apps.tsx
@@ -3,8 +3,6 @@ import { AppDetails } from "./app-details";
 import { Helmet } from "inferno-helmet";
 import { i18n } from "../i18next";
 
-const title = i18n.t("apps_title");
-
 export class Apps extends Component<any, any> {
   constructor(props: any, context: any) {
     super(props, context);
@@ -15,6 +13,7 @@ export class Apps extends Component<any, any> {
   }
 
   render() {
+    const title = i18n.t("apps_title");
     return (
       <div>
         <Helmet title={title}>

--- a/src/shared/components/contact.tsx
+++ b/src/shared/components/contact.tsx
@@ -2,13 +2,12 @@ import { Component } from "inferno";
 import { Helmet } from "inferno-helmet";
 import { i18n } from "../i18next";
 
-const title = i18n.t("contact_title");
-
 export class Contact extends Component<any, any> {
   constructor(props: any, context: any) {
     super(props, context);
   }
   render() {
+    const title = i18n.t("contact_title");
     return (
       <div>
         <Helmet title={title}>

--- a/src/shared/components/donate.tsx
+++ b/src/shared/components/donate.tsx
@@ -7,7 +7,6 @@ import { translators } from "../translations/translators";
 import { languagesAll, countries } from "countries-list";
 import { isBrowser } from "../utils";
 
-const title = i18n.t("support_title");
 const avatarSize = 40;
 const bannerWidth = 240;
 const bannerHeight = 101;
@@ -92,6 +91,7 @@ export class Donate extends Component<any, any> {
   }
 
   render() {
+    const title = i18n.t("support_title");
     return (
       <div>
         <Helmet title={title}>

--- a/src/shared/components/instances.tsx
+++ b/src/shared/components/instances.tsx
@@ -4,14 +4,14 @@ import { i18n } from "../i18next";
 import { instance_stats } from "../instance_stats";
 import { numToSI } from "../utils";
 
-const title = i18n.t("join_title");
-
 export class Instances extends Component<any, any> {
   constructor(props: any, context: any) {
     super(props, context);
   }
 
   render() {
+    const title = i18n.t("join_title");
+
     var recommended_instances = instance_stats.recommended[i18n.language];
     if (!recommended_instances) {
       recommended_instances = instance_stats.recommended["en"];

--- a/src/shared/components/main.tsx
+++ b/src/shared/components/main.tsx
@@ -6,8 +6,6 @@ import { i18n } from "../i18next";
 import { T } from "inferno-i18next";
 import { getDocsLanguage, isBrowser } from "../utils";
 
-const title = i18n.t("lemmy_title");
-
 export class Main extends Component<any, any> {
   constructor(props: any, context: any) {
     super(props, context);
@@ -40,6 +38,7 @@ export class Main extends Component<any, any> {
   }
 
   render() {
+    const title = i18n.t("lemmy_title");
     return (
       <div>
         <Helmet title={title}>


### PR DESCRIPTION
Fixes #143

By the way, there are two translation keys I think aren't used: `about_title` and `sponsors_title`.