### PR TITLE
Remove email address from contact page

### DIFF
--- a/src/shared/components/contact.tsx
+++ b/src/shared/components/contact.tsx
@@ -26,9 +26,6 @@ export class Contact extends Component<any, any> {
             <li>
               <a href="https://github.com/LemmyNet">GitHub</a>
             </li>
-            <li>
-              <a href="mailto:contact@join-lemmy.org">contact@join-lemmy.org</a>
-            </li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
People are using it for basic support which should go through other channels