### PR TITLE
Dont list instances with closed signups or few active users

### DIFF
--- a/src/shared/components/instances.tsx
+++ b/src/shared/components/instances.tsx
@@ -4,6 +4,8 @@ import { i18n } from "../i18next";
 import { instance_stats } from "../instance_stats";
 import { numToSI } from "../utils";
 
+const min_monthly_users = 5;
+
 export class Instances extends Component<any, any> {
   constructor(props: any, context: any) {
     super(props, context);
@@ -90,6 +92,11 @@ export class Instances extends Component<any, any> {
             .filter(
               i =>
                 i.site_info.site_view.local_site.registration_mode != "closed"
+            )
+            .filter(
+              i =>
+                i.site_info.site_view.counts.users_active_month >
+                min_monthly_users
             )
             .map(instance => {
               let domain = instance.domain;

--- a/src/shared/components/instances.tsx
+++ b/src/shared/components/instances.tsx
@@ -86,51 +86,56 @@ export class Instances extends Component<any, any> {
       <div>
         <h2>{header}</h2>
         <div class="row">
-          {instances.map(instance => {
-            let domain = instance.domain;
-            let users_active_month =
-              instance.site_info.site_view.counts.users_active_month;
-            let description = instance.site_info.site_view.site.description;
-            let icon = instance.site_info.site_view.site.icon;
-            let require_application =
-              instance.site_info.site_view.site.require_application;
-            return (
-              <div class="card col-6">
-                <header>
-                  <div class="row">
-                    <h4 class="col">{domain}</h4>
-                    <h4 class="col text-right">
-                      <i>
-                        {i18n.t("users_active_per_month", {
-                          count: users_active_month,
-                          formattedCount: numToSI(users_active_month),
-                        })}
-                      </i>
-                    </h4>
+          {instances
+            .filter(
+              i =>
+                i.site_info.site_view.local_site.registration_mode != "closed"
+            )
+            .map(instance => {
+              let domain = instance.domain;
+              let users_active_month =
+                instance.site_info.site_view.counts.users_active_month;
+              let description = instance.site_info.site_view.site.description;
+              let icon = instance.site_info.site_view.site.icon;
+              let require_application =
+                instance.site_info.site_view.site.require_application;
+              return (
+                <div class="card col-6">
+                  <header>
+                    <div class="row">
+                      <h4 class="col">{domain}</h4>
+                      <h4 class="col text-right">
+                        <i>
+                          {i18n.t("users_active_per_month", {
+                            count: users_active_month,
+                            formattedCount: numToSI(users_active_month),
+                          })}
+                        </i>
+                      </h4>
+                    </div>
+                  </header>
+                  <div class="is-center">
+                    <img
+                      class="join-banner"
+                      src={icon || "/static/assets/images/lemmy.svg"}
+                    />
                   </div>
-                </header>
-                <div class="is-center">
-                  <img
-                    class="join-banner"
-                    src={icon || "/static/assets/images/lemmy.svg"}
-                  />
+                  <br />
+                  <p class="join-desc">{description}</p>
+                  <footer>
+                    {require_application ? (
+                      <a class="button primary" href={`https://${domain}`}>
+                        {i18n.t("apply_to_join")}
+                      </a>
+                    ) : (
+                      <a class="button primary" href={`https://${domain}`}>
+                        {i18n.t("join")}
+                      </a>
+                    )}
+                  </footer>
                 </div>
-                <br />
-                <p class="join-desc">{description}</p>
-                <footer>
-                  {require_application ? (
-                    <a class="button primary" href={`https://${domain}`}>
-                      {i18n.t("apply_to_join")}
-                    </a>
-                  ) : (
-                    <a class="button primary" href={`https://${domain}`}>
-                      {i18n.t("join")}
-                    </a>
-                  )}
-                </footer>
-              </div>
-            );
-          })}
+              );
+            })}
         </div>
       </div>
     );


### PR DESCRIPTION
Instances shouldnt be listed if signups are closed.

Also added a filter so that instances with less than 5 users are not listed. The specific number is debatable but it doesnt make much sense to list inactive instances.