### PR TITLE
Remove the Active Users count from Instance cards

### DIFF
--- a/src/shared/components/instances.tsx
+++ b/src/shared/components/instances.tsx
@@ -99,14 +99,6 @@ export class Instances extends Component<any, any> {
                 <header>
                   <div class="row">
                     <h4 class="col">{domain}</h4>
-                    <h4 class="col text-right">
-                      <i>
-                        {i18n.t("users_active_per_month", {
-                          count: users_active_month,
-                          formattedCount: numToSI(users_active_month),
-                        })}
-                      </i>
-                    </h4>
                   </div>
                 </header>
                 <div class="is-center">


### PR DESCRIPTION
As discussed here: https://lemmy.world/comment/29874

> I think we should remove the “users per month” number on the instance list. It’s confusing to newbies and encourages people to join a “large” instance when the number doesn’t really correlate with actual server capacity.