### PR TITLE
Add lemm.ee to recommended instances

### DIFF
--- a/recommended-instances.json
+++ b/recommended-instances.json
@@ -5,7 +5,8 @@
     "sh.itjust.works",
     "lemmy.fmhy.ml",
     "vlemmy.net",
-    "discuss.tchncs.de"
+    "discuss.tchncs.de",
+    "lemm.ee"
   ],
   "fr": ["sh.itjust.works"],
   "da": ["feddit.dk"],


### PR DESCRIPTION
Hey! I would like to propose lemm.ee as a recommended instance.

We have 80 users so far. We have some simple rules in the sidebar and there is an introductory post here: https://lemm.ee/post/26

Sign-ups are open and community creation is enabled for all users.