### PR TITLE
Expand Explanatory Text on the Instances Page for New Users

### DIFF
--- a/src/shared/components/instances.tsx
+++ b/src/shared/components/instances.tsx
@@ -1,6 +1,7 @@
 import { Component } from "inferno";
 import { Helmet } from "inferno-helmet";
 import { i18n } from "../i18next";
+import { T } from "inferno-i18next";
 import { instance_stats } from "../instance_stats";
 import { numToSI } from "../utils";
 
@@ -52,34 +53,84 @@ export class Instances extends Component<any, any> {
 
   header() {
     return (
-      <i>
-        {i18n.t("instance_totals", {
-          instances: numToSI(instance_stats.stats.crawled_instances),
-          users: numToSI(instance_stats.stats.users_active_month),
-        })}
+      <>
+        <T i18nKey="instance_explanation">
+          #
+          <p>
+            <strong>#</strong>
+          </p>
+          <ul>
+            <li>#</li>
+          </ul>
+        </T>
         <p>
-          {i18n.t("instance_comparison")}:
+          <T i18nKey="choose_instance">
+            #<strong>#</strong>
+          </T>
+        </p>
+        <p>
+          {i18n.t("instance_totals", {
+            instances: numToSI(instance_stats.stats.crawled_instances),
+            users: numToSI(instance_stats.stats.users_active_month),
+          })}
+        </p>
+        <T i18nKey="instance_comparison">
+          #<p>#</p>
           <ul>
             <li>
-              <a href="https://github.com/maltfield/awesome-lemmy-instances">
-                Awesome-Lemmy-Instances on GitHub
+              <a
+                target="_blank"
+                href="https://github.com/maltfield/awesome-lemmy-instances"
+              >
+                #
               </a>
             </li>
             <li>
-              <a href="https://the-federation.info/platform/73">
-                the-federation.info Lemmy Instances Page
+              <a target="_blank" href="https://the-federation.info/platform/73">
+                #
               </a>
             </li>
             <li>
-              <a href="https://lemmymap.feddit.de/">Feddit's Lemmymap</a>
+              <a target="_blank" href="https://fedidb.org/software/lemmy">
+                #
+              </a>
+            </li>
+            <li>
+              <a target="_blank" href="https://lemmymap.feddit.de/">
+                #
+              </a>
             </li>
           </ul>
-          {i18n.t("instance_browser")}{" "}
-          <a href="https://browse.feddit.de/">
-            Feddit's Lemmy Community Browser
-          </a>
+        </T>
+        <p>
+          <T i18nKey="join_instance">
+            #
+            <a
+              target="_blank"
+              href="https://join-lemmy.org/docs/en/users/01-getting-started.html#registration"
+            >
+              #
+            </a>
+          </T>
         </p>
-      </i>
+        <p>
+          <T i18nKey="instance_browser">
+            #
+            <a target="_blank" href="https://browse.feddit.de/">
+              #
+            </a>
+            <a target="_blank" href="https://lemmy.ml/post/1160417">
+              #
+            </a>
+            <a
+              target="_blank"
+              href="https://join-lemmy.org/docs/en/users/01-getting-started.html#following-communities"
+            >
+              #
+            </a>
+          </T>
+        </p>
+      </>
     );
   }
 


### PR DESCRIPTION
As follow-on from <https://lemmy.ml/post/1160417>, this PR proposes revisions to the text at the top of <https://join-lemmy.org/instances>.  It depends on <https://github.com/LemmyNet/joinlemmy-translations/pull/14>.

I expect that some of the changes may require discussion, but, in summary, they are:

*   Moves and bolds the message about users only needing to sign up for one instance.
*   Describes how a user's choice of instance will matter.
*   Describes how to choose an instance, including a bolded warning that users should avoid crowded instances.
*   Adds [FediDB's Lemmy Instances Page](https://lemmymap.feddit.de/) to the list of instance-comparison sites.
*   Explains how to sign up after visiting an instance (since the "Join" buttons do not go directly to signup pages).
*   Adds links to the user guide.
*   Adds a link to my post in !lemmy@lemmy.ml.

The revised text looks like this in the English translation:

> # Lemmy servers
>
> To use Lemmy, you need to be a member of **one instance**. You will still be able to see content from anywhere, but the instance you choose will determine:
>
> *   What URL you use to log in to Lemmy,
> *   What content shows on the homepage when you select "Local" or "All",
> *   Who moderates your instance, and
> *   What rules you agree to when you sign up.
>
> Choose an instance that matches your interests, language, and region. **Please avoid joining instances that are already crowded (1K+ users/month).** If an instance gets overcrowded, it can start running slowly or experiencing downtime, so choosing an uncrowded instance will give both you and others a better Lemmy experience.
>
> The Lemmyverse currently has 260 instances, and 7.5K monthly active users.
>
> For a more detailed comparison of Lemmy instances, see:
>
> *   [Awesome-Lemmy-Instances on GitHub](https://the-federation.info/platform/73)
> *   [the-federation.info Lemmy Instances Page](https://fedidb.org/software/lemmy)
> *   [FediDB's Lemmy Instances Page](https://lemmymap.feddit.de/)
> *   [Feddit's Lemmymap](https://github.com/maltfield/awesome-lemmy-instances)
>
> To join an instance, tap its "Join" button and then choose "Sign Up" from the toolbar. For detailed instructions, see [the Lemmy Documentation](https://join-lemmy.org/docs/en/users/01-getting-started.html#registration).
>
> After you create an account, you can set up your profile and find communities using [Feddit's Lemmy Community Browser](https://browse.feddit.de/) as described [here](https://lemmy.ml/post/1160417) and [here](https://join-lemmy.org/docs/en/users/01-getting-started.html#following-communities).

Partially addresses LemmyNet#167 by including more prominent links to the user guide.
