### PR TITLE
Increase memory for Docker prod build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ COPY --from=docs /app/docs ./src/assets/docs
 COPY --from=api /app/lemmy-js-client/docs ./src/assets/api
 
 RUN yarn
-RUN yarn build:prod
+RUN NODE_OPTIONS="--max-old-space-size=8192" yarn build:prod
 
 FROM node:14-alpine as runner
 COPY --from=builder /app/dist /app/dist


### PR DESCRIPTION
Kept failing with `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`. This change fixes it.

https://stackoverflow.com/a/59572966