### PR TITLE
Updated Lemmy Matrix Support link

### DIFF
--- a/src/assets/news/2023-06-23 - Lemmy Release v0.18.0.md
+++ b/src/assets/news/2023-06-23 - Lemmy Release v0.18.0.md
@@ -80,7 +80,7 @@ The installation instructions have been slightly updated. However there are no b
 
 Follow the upgrade instructions for [ansible](https://github.com/LemmyNet/lemmy-ansible#upgrading) or [docker](https://join-lemmy.org/docs/en/administration/install_docker.html#updating).
 
-If you need help with the upgrade, you can ask in our [support forum](https://lemmy.ml/c/lemmy_support) or on the [Matrix Chat](https://matrix.to/#/!OwmdVYiZSXrXbtCNLw:matrix.org).
+If you need help with the upgrade, you can ask in our [support forum](https://lemmy.ml/c/lemmy_support) or on the [Matrix Chat](https://matrix.to/#/#lemmy-admin-support-topics:discuss.online).
 
 ## Support development
 


### PR DESCRIPTION
Updated references to the old matrix channel to be to https://matrix.to/#/#lemmy-admin-support-topics:discuss.online instead.

I've updated the Matrix link to use the new Space to help people find the correct support.

Relates to:
https://github.com/LemmyNet/lemmy/pull/3599
https://github.com/LemmyNet/lemmy-docs/pull/248