### PR TITLE
Remove a no longer updated link

### DIFF
--- a/src/shared/components/instances.tsx
+++ b/src/shared/components/instances.tsx
@@ -91,11 +91,6 @@ export class Instances extends Component<any, any> {
           {i18n.t("instance_comparison")}:
           <ul>
             <li>
-              <a href="https://github.com/maltfield/awesome-lemmy-instances">
-                Awesome-Lemmy-Instances on GitHub
-              </a>
-            </li>
-            <li>
               <a href="https://the-federation.info/platform/73">
                 the-federation.info Lemmy Instances Page
               </a>


### PR DESCRIPTION
The link hasn't been updated for over a month and I think it actively hurts new users when they click for example VLemmy, which no longer exists, as the 2nd most recommended instance.