### PR TITLE
adding back 'awesome-lemmy-instances' after freeze ended

### DIFF
--- a/src/shared/components/instances.tsx
+++ b/src/shared/components/instances.tsx
@@ -91,6 +91,11 @@ export class Instances extends Component<any, any> {
           {i18n.t("instance_comparison")}:
           <ul>
             <li>
+              <a href="https://github.com/maltfield/awesome-lemmy-instances">
+                Awesome-Lemmy-Instances on GitHub
+              </a>
+            </li>
+            <li>
               <a href="https://the-federation.info/platform/73">
                 the-federation.info Lemmy Instances Page
               </a>


### PR DESCRIPTION
The intentional [update freeze](https://github.com/maltfield/awesome-lemmy-instances/issues/26) has ended after a ~4-week grace period has passed allowing instance admins to upgrade after the [breaking changes](https://github.com/LemmyNet/lemmy-stats-crawler/issues/9#issuecomment-1611991067) to lemmy-stats-crawler.

 * https://github.com/maltfield/awesome-lemmy-instances/issues/26
 * https://github.com/LemmyNet/joinlemmy-site/pull/227

The [Awesome Lemmy Instances](https://github.com/maltfield/awesome-lemmy-instances/) repo has been set back to update itself every 1 hour.