### PR TITLE
More compact listing for mobile apps

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -14,6 +14,10 @@
   webkit-box-shadow: unset;
   box-shadow: unset;
   border: 1px solid var(--color-darkGrey) !important;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 .stylized {
   font-family: "CaviarDreams", Fallback, sans-serif;
@@ -44,8 +48,8 @@ p {
 }
 .app-icon {
   display: inline-block;
-  height: 30px;
-  width: 30px;
+  height: 60px;
+  width: 60px;
   margin-right: 10px;
 }
 img {

--- a/src/shared/components/apps.tsx
+++ b/src/shared/components/apps.tsx
@@ -1,5 +1,6 @@
 import { Component } from "inferno";
 import { AppDetails } from "./app-details";
+import { CompactAppDetails } from "./compact-app-details";
 import { Helmet } from "inferno-helmet";
 import { i18n } from "../i18next";
 
@@ -24,13 +25,12 @@ export class Apps extends Component<any, any> {
           <p>{i18n.t("choose_from_apps")}</p>
 
           <div class="row">
-            <div class="card col-6">
-              <AppDetails
+            <div class="card col-6 col-4-md">
+              <CompactAppDetails
                 name="Jerboa"
                 description="A native Android app made by Lemmy's developers"
                 link="https://github.com/dessalines/jerboa"
                 icon="/static/assets/images/jerboa.svg"
-                banner="/static/assets/images/jerboa_screen.webp"
                 links={[
                   {
                     link: "https://f-droid.org/en/packages/com.jerboa",
@@ -47,13 +47,12 @@ export class Apps extends Component<any, any> {
                 ]}
               />
             </div>
-            <div class="card col-6">
-              <AppDetails
+            <div class="card col-6 col-4-md">
+              <CompactAppDetails
                 name="Mlem"
                 description="A Lemmy Client for iOS."
                 link="https://github.com/mormaer/Mlem"
                 icon="/static/assets/images/mlem.png"
-                banner="/static/assets/images/mlem_screen.webp"
                 links={[
                   {
                     link: "https://testflight.apple.com/join/MelFP11Y",
@@ -66,13 +65,12 @@ export class Apps extends Component<any, any> {
                 ]}
               />
             </div>
-            <div class="card col-6">
-              <AppDetails
+            <div class="card col-6 col-4-md">
+              <CompactAppDetails
                 name="Memmy"
                 description="A Lemmy Client built in React Native for iOS available on the App Store."
                 link="https://github.com/Memmy-App/memmy"
                 icon="/static/assets/images/memmy_icon.png"
-                banner="/static/assets/images/memmy_banner.webp"
                 links={[
                   {
                     link: "https://apps.apple.com/us/app/memmy-for-lemmy/id6450204299?platform=iphone",
@@ -85,13 +83,12 @@ export class Apps extends Component<any, any> {
                 ]}
               />
             </div>
-            <div class="card col-6">
-              <AppDetails
+            <div class="card col-6 col-4-md">
+              <CompactAppDetails
                 name="Voyager"
                 description="A Lemmy Client for iOS, Android and the web"
                 link="https://github.com/aeharding/voyager"
                 icon="/static/assets/images/voyager.png"
-                banner="/static/assets/images/voyager_screen.webp"
                 links={[
                   {
                     link: "https://apps.apple.com/us/app/voyager-for-lemmy/id6451429762?platform=iphone",

--- a/src/shared/components/compact-app-details.tsx
+++ b/src/shared/components/compact-app-details.tsx
@@ -1,0 +1,44 @@
+import { Component } from "inferno";
+import { Icon } from "./icon";
+
+interface CompactAppDetailsProps {
+  name: string;
+  description: string;
+  link: string;
+  icon?: string;
+  links: AppLink[];
+}
+
+interface AppLink {
+  link: string;
+  icon: string;
+}
+
+export class CompactAppDetails extends Component<CompactAppDetailsProps, any> {
+  constructor(props: any, context: any) {
+    super(props, context);
+  }
+  render() {
+    let p = this.props;
+    let icon = p.icon || "/static/assets/images/lemmy.svg";
+
+    return (
+      <>
+        <header class="is-left">
+          <img class="app-icon" src={icon} />
+          <h3>
+            <a href={p.link}>{p.name}</a>
+          </h3>
+        </header>
+        <p>{p.description}</p>
+        <footer class="is-right">
+          {p.links.map(l => (
+            <a class="button primary" href={l.link}>
+              <Icon icon={l.icon} />
+            </a>
+          ))}
+        </footer>
+      </>
+    );
+  }
+}


### PR DESCRIPTION
There are quite a few mobile clients for Lemmy and even if the website chooses to only list the most significant (I will add these later), a more compact listing is needed. At present each row takes up an entire screen.

This commit removes the banner and emphasizes the icon and title. 3 columns are shown on wider screens, 2 on smaller ones and 1 on mobile.

![lemmy](https://github.com/LemmyNet/joinlemmy-site/assets/61007604/e4ff6d62-e9d5-46e2-a3b6-953af5e71d1f)

I've left sections other than mobile apps untouched, I'm not sure they need to be more compact.