### PR TITLE
Update go-lemmy URL

### DIFF
--- a/src/shared/components/apps.tsx
+++ b/src/shared/components/apps.tsx
@@ -227,8 +227,8 @@ export class Apps extends Component<any, any> {
               - a dart / flutter client.
             </li>
             <li>
-              <a href="https://gitea.elara.ws/Elara6331/go-lemmy">go-lemmy</a> - a
-              Go client.
+              <a href="https://gitea.elara.ws/Elara6331/go-lemmy">go-lemmy</a> -
+              a Go client.
             </li>
           </ul>
         </div>

--- a/src/shared/components/apps.tsx
+++ b/src/shared/components/apps.tsx
@@ -227,7 +227,7 @@ export class Apps extends Component<any, any> {
               - a dart / flutter client.
             </li>
             <li>
-              <a href="https://github.com/Arsen6331/go-lemmy">go-lemmy</a> - a
+              <a href="https://gitea.elara.ws/Elara6331/go-lemmy">go-lemmy</a> - a
               Go client.
             </li>
           </ul>


### PR DESCRIPTION
The main repo for `go-lemmy` is on my Gitea instance. This PR updates the URL for go-lemmy to the correct URL.