### PR TITLE
Exclude pedo instance

### DIFF
--- a/recommended-instances.json
+++ b/recommended-instances.json
@@ -28,6 +28,7 @@
     "burggit.moe",
     "lemmy.burger.rodeo",
     "bakchodi.org",
-    "lemmy.comfysnug.space"
+    "lemmy.comfysnug.space",
+    "rqd2.net"
   ]
 }


### PR DESCRIPTION
Another sus instance showed up. [People have found a bunch of "minor attracted person" stuff on that instance](https://sh.itjust.works/post/6400367), so this should definitely be excluded.