### PR TITLE
Add dormi.zone to instances-definitions.ts

### DIFF
--- a/src/shared/components/instances-definitions.ts
+++ b/src/shared/components/instances-definitions.ts
@@ -486,4 +486,9 @@ export const RECOMMENDED_INSTANCES: RecommendedInstance[] = [
     languages: ["en", "cs"],
     topics: [GENERAL, TECHNOLOGY, GAMING],
   },
+  {
+    domain: "dormi.zone",
+    languages: ["en"],
+    topics: [GAMING],
+  },
 ];


### PR DESCRIPTION
Following the instructions in [this news](https://join-lemmy.org/news/2023-10-31_-_Join-Lemmy_Redesign_and_Funding_Drive), this adds the server language and server topic for my instance https://dormi.zone.