### PR TITLE
Use the Thunder team's Dart client

### DIFF
--- a/src/shared/components/app-definitions.ts
+++ b/src/shared/components/app-definitions.ts
@@ -40,10 +40,10 @@ export const API_LIBRARIES: ApiLibrary[] = [
     description: "a javascript / typescript client.",
   },
   {
-    name: "lemmy-dart client",
+    name: "lemmy_api_client",
 
-    link: "https://github.com/LemmurOrg/lemmy_api_client",
-    description: "a dart / flutter client.",
+    link: "https://github.com/thunder-app/lemmy_api_client",
+    description: "a Dart / Flutter client.",
   },
   {
     name: "go-lemmy",


### PR DESCRIPTION
Hi! I noticed that https://join-lemmy.org/apps was referencing an [old Dart client from LemmurOrg](https://github.com/LemmurOrg/lemmy_api_client) which was archived in Feb 2023. That client was [forked](https://github.com/liftoff-app/lemmy_api_client/) and maintained by a while by the developer(s) of Liftoff, but that also appears to have gone dead (no updates in 6 months, no support for Lemmy 0.19.x). Over at Thunder, we have made [yet another fork](https://github.com/thunder-app/lemmy_api_client) and are actively maintaining it, which we think would make a good addition to the site.

Tagging @hjiangsu, the primary maintainer!