### PR TITLE
Add CORS header to context.json for JSON-LD playground to work

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -1,4 +1,9 @@
-import express, { RequestHandler, Request, Response } from "express";
+import express, {
+  RequestHandler,
+  Request,
+  Response,
+  NextFunction,
+} from "express";
 import { StaticRouter } from "inferno-router";
 import { renderToString } from "inferno-server";
 // import { matchPath } from "inferno-router";
@@ -12,6 +17,11 @@ import { getLanguageFromCookie, i18n } from "../shared/i18next";
 const server = express();
 const port = 1234;
 
+function cors(_req: Request, res: Response, next: NextFunction): void {
+  res.header("Access-Control-Allow-Origin", "*");
+  next();
+}
+
 server.use(express.json() as RequestHandler);
 server.use(express.urlencoded({ extended: false }) as RequestHandler);
 server.use("/static", express.static(path.resolve("./dist")));
@@ -19,6 +29,7 @@ server.use("/docs", express.static(path.resolve("./dist/assets/docs")));
 server.use("/api", express.static(path.resolve("./dist/assets/api")));
 server.use(
   "/context.json",
+  cors,
   express.static(path.resolve("./dist/assets/lemmy_federation_context.json")),
 );
 server.use("/feed.xml", express.static(path.resolve("./dist/feed.xml")));


### PR DESCRIPTION
Try pasting the following into the editor at https://json-ld.org/playground/
```
{
  "@context": [
    "https://www.w3.org/ns/activitystreams",
    "https://join-lemmy.org/context.json"
  ],
  "id": "https://enterprise.lemmy.ml/post/55143",
  "type": "Page",
  "audience": "https://enterprise.lemmy.ml/c/tenforward",
  "name": "Post title",
  "content": "<p>This is a post in the /c/tenforward community</p>\n",
  "tag": [
    {
      "type": "lemmy:CommunityPostTag",
      "id": "https://enterprise.lemmy.ml/c/tenforward/tag/news",
      "name": "News"
    }
  ]
}
```

You will get this error: 
![image](https://github.com/user-attachments/assets/1b4a114c-b06f-478d-8404-aff34f3362a5)

Allowing CORS here seems harmless and makes it easier to verify whether Lemmy AP objects  are interpreted correctly and valid.