### PR TITLE
Update instance crawler start instances

### DIFF
--- a/recommended-instances.json
+++ b/recommended-instances.json
@@ -9,9 +9,8 @@
     "lemmy.sdf.org",
     "feddit.uk",
     "hexbear.net",
-    "lemmy.fmhy.ml",
     "discuss.online",
-    "feddit.de",
+    "feddit.org",
     "lemmings.world"
   ],
   "exclude": [


### PR DESCRIPTION
- lemmy.fmhy.ml is long dead since their domain was taken away
- feddit.de died a while back, feddit.org is its spiritual successor