### PR TITLE
Update F-Droid link for Eternity client

### DIFF
--- a/src/shared/components/app-definitions.ts
+++ b/src/shared/components/app-definitions.ts
@@ -186,7 +186,7 @@ const ETERNITY: AppDetails = {
   banner: "/static/assets/images/eternity_screen.webp",
   links: [
     {
-      link: "https://apt.izzysoft.de/fdroid/index/apk/eu.toldi.infinityforlemmy",
+      link: "https://f-droid.org/en/packages/eu.toldi.infinityforlemmy",
       icon: "f-droid",
     },
     {


### PR DESCRIPTION
The Eternity client is no longer available on the IzzyOnDroid repository and is now on the main F-Droid repo instead. 
See https://apt.izzysoft.de/fdroid/index/apk/eu.toldi.infinityforlemmy