### PR TITLE
Renovate should only apply security updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "schedule": ["every weekend"],
-  "automerge": true
+  "automerge": true,
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchPackageNames": ["*"]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true
 }


### PR DESCRIPTION
This way we can avoid problems such as https://github.com/LemmyNet/joinlemmy-site/issues/431. Anyway there is no reason to use latest library versions other than security.

https://docs.renovatebot.com/presets-security/#securityonly-security-updates