### PR TITLE
Update topics selections for lemmy.radio

### DIFF
--- a/src/shared/components/instances-definitions.ts
+++ b/src/shared/components/instances-definitions.ts
@@ -382,7 +382,7 @@ export const RECOMMENDED_INSTANCES: RecommendedInstance[] = [
   {
     domain: "lemmy.radio",
     languages: ["en"],
-    topics: [MUSIC, HOBBIES],
+    topics: [TECHNOLOGY, HOBBIES],
   },
   {
     domain: "feddit.ch",


### PR DESCRIPTION
lemmy.radio instance admin here 👋 

## Change

Removes "MUSIC" topic and adds "TECHNOLOGY". 

## Reason

This instance is for amateur or "ham" radio, not music radio. Amateur Radio is a technology based hobby and topic.