### PR TITLE
Bigger text size for donate page

### DIFF
--- a/src/shared/components/donate.tsx
+++ b/src/shared/components/donate.tsx
@@ -40,7 +40,7 @@ export class Donate extends Component<any, any> {
 }
 
 const DonateDesc = () => (
-  <p className="text-gray-300 mb-3 text-justify">
+  <p className="text-gray-300 mb-3 text-justify prose">
     <T i18nKey="donate_desc">
       <br />
       <br />


### PR DESCRIPTION
Not sure why it got so small.

Before:
![Screenshot_20250516_125742](https://github.com/user-attachments/assets/b7cc2144-0fe6-47de-be16-5eb8d3727227)
After:
![Screenshot_20250516_125850](https://github.com/user-attachments/assets/e410f13d-de65-4714-a2c1-3b24d26d6bc6)
