### PR TITLE
Fix icon overflows by using inline-flex.

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -61,7 +61,7 @@
 }
 
 .icon {
-  @apply block max-w-16 max-h-16 stroke-0 stroke-current fill-current;
+  @apply inline-flex max-w-16 max-h-16 stroke-0 stroke-current fill-current;
 }
 
 @font-face {


### PR DESCRIPTION
- Fixes #510

<img width="300" height="572" alt="Screenshot_2026-01-14-10-27-18-350_mark via" src="https://github.com/user-attachments/assets/65fd9fa6-a0a9-4ad0-81f9-271fdf37308f" />
