### PR TITLE
Change Lemmyverse link to instance list

### DIFF
--- a/src/shared/components/instances-definitions.ts
+++ b/src/shared/components/instances-definitions.ts
@@ -8,8 +8,8 @@ export interface InstanceHelper {
 
 export const INSTANCE_HELPERS: InstanceHelper[] = [
   {
-    name: "Lemmy Community Explorer",
-    link: "https://lemmyverse.net/communities",
+    name: "Lemmy Instance Explorer",
+    link: "https://lemmyverse.net",
   },
   {
     name: "Lemmy Fediverse Observer",


### PR DESCRIPTION
The current link is broken (https://github.com/tgxn/lemmy-explorer/issues/304), and as we are on the instance page it should link to a list of communities anyway.