### PR TITLE
Handle long country name for instances

### DIFF
--- a/src/shared/components/instances.tsx
+++ b/src/shared/components/instances.tsx
@@ -145,7 +145,7 @@ class InstanceCard extends Component<InstanceCardProps, InstanceCardState> {
     return (
       <div className="card card-bordered bg-neutral-900 shadow-xl">
         <div className="card-body p-4">
-          <div className="flex flex-row flex-wrap gap-4">
+          <div className="flex flex-row gap-4">
             {this.state.showModal && (
               <DetailsModal
                 id={modalId}
@@ -214,7 +214,7 @@ const InstanceIcon = ({ domain, icon }) => (
 );
 
 const InstanceStats = ({ geoIp, emailRequired, monthlyUsers }) => (
-  <div className="flex flex-col flex-wrap gap-2">
+  <div className="flex flex-col flex-nowrap h-min gap-2">
     <StatsBadges
       geoIp={geoIp}
       emailRequired={emailRequired}
@@ -227,7 +227,7 @@ export const StatsBadges = ({ monthlyUsers, emailRequired, geoIp }) => (
   <>
     <Badge
       content={
-        <div className="text-sm text-gray-500 tooltip">
+        <div className="text-sm text-gray-500 tooltip text-ellipsis whitespace-nowrap">
           <Icon icon="globe" classes="mr-2" />
           <span>{geoIp?.country?.names?.en ?? i18n.t("country_unknown")}</span>
         </div>


### PR DESCRIPTION
This solution works well enough:
<img width="688" height="494" alt="Screenshot_20260122_151450" src="https://github.com/user-attachments/assets/75b7b393-5021-4709-9165-641ae3297d2e" />

Although for longer names it breaks, couldnt figure out a solution:
<img width="338" height="363" alt="Screenshot_20260122_154117" src="https://github.com/user-attachments/assets/61504c7e-d440-459b-9db3-3e309985e7eb" />


Anyway its good enough.