### PR TITLE
Add ts-nocheck to instance_definitions.test

### DIFF
--- a/src/shared/instance_definitions.test.ts
+++ b/src/shared/instance_definitions.test.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 jest.setTimeout(180000);
 import { RECOMMENDED_INSTANCES } from "./components/instances-definitions";
 


### PR DESCRIPTION
Figured it out: its because it wasn't an eslint error, but a `tsc` one (if you check the `pnpm lint` command).