### PR TITLE
Remove lemmy.org from suggestions (ref #545)

### DIFF
--- a/src/shared/data/instances-definitions.ts
+++ b/src/shared/data/instances-definitions.ts
@@ -31,7 +31,7 @@ export const SUGGESTED_INSTANCES: SuggestedInstancesType = {
   nl: ["lemy.nl"],
   es: ["chachara.club"],
   lt: ["group.lt"],
-  fallback: ["thelemmy.club", "lemmus.org", "lemmy.org"],
+  fallback: ["thelemmy.club", "lemmus.org"],
 };
 
 export const INSTANCE_HELPERS: InstanceHelper[] = [


### PR DESCRIPTION
- Two day old spam posts on local feed
- Only one admin, who according to his bio is CEO of advertising and AI companies