### PR TITLE
Use relative url for suggested instance

### DIFF
--- a/src/shared/components/main.tsx
+++ b/src/shared/components/main.tsx
@@ -313,7 +313,7 @@ export class Main extends Component<Props, State> {
     // TODO: Should be able to initialize this during SSR by passing in client ip, but
     //       complicated to get it working.
     if (isBrowser()) {
-      const url = `${window.location.href}api/v1/instances/suggested`;
+      const url = `/api/v1/instances/suggested`;
       fetch(url)
         .then(res => {
           res


### PR DESCRIPTION
Noticed that this was failing after changing the language, turns out it was making a request to `https://join-lemmy.org/?lang=enapi/v1/instances/suggested`