### PR TITLE
apps: default desktop visitors to web clients

### DIFF
--- a/src/shared/components/apps.tsx
+++ b/src/shared/components/apps.tsx
@@ -209,12 +209,6 @@ export class Apps extends Component<object, State> {
       return "ios";
     } else if (info.includes("android") || info.includes("mobile")) {
       return "android";
-    } else if (
-      info.includes("linux") ||
-      info.includes("windows") ||
-      info.includes("macos")
-    ) {
-      return "desktop";
     } else {
       return "web";
     }


### PR DESCRIPTION
- `desktop` auto-default only matched apps shipping native builds — hid every web client from desktop visitors.
- Web clients run instantly in a desktop browser; native is the niche case.
- Native desktop apps (Neonmodem, Blorp) still listed under the `desktop` dropdown option.
