### PR TITLE
Fix news title

### DIFF
--- a/src/assets/news/2026-07-27 - Lemmy Release v0.19.20 - Reduced Memory Usage.md
+++ b/src/assets/news/2026-07-27 - Lemmy Release v0.19.20 - Reduced Memory Usage.md
@@ -1,3 +1,5 @@
+# Lemmy Release v0.19.20 - Reduced Memory Usage
+
 ## What is Lemmy?
 
 Lemmy is a self-hosted social link aggregation and discussion platform. It is completely free and open, and not controlled by any company. This means that there is no advertising, tracking, or secret algorithms. Content is organized into communities, so it is easy to subscribe to topics that you are interested in, and ignore others. Voting is used to bring the most interesting items to the top.

--- a/src/shared/components/news.tsx
+++ b/src/shared/components/news.tsx
@@ -18,7 +18,9 @@ interface NewsInfo {
 
 function buildNewsInfoArray(): Array<NewsInfo> {
   return news_reversed.map(n => {
-    const split = n.title.split(" - ");
+    // split only once
+    const i = n.title.indexOf(" - ");
+    const split = [n.title.slice(0, i), n.title.slice(i + 3)];
 
     return {
       dateStr: split[0],


### PR DESCRIPTION
Title of the latest release is rendered wrong on https://join-lemmy.org/news, this change fixes it:

<img width="998" height="342" alt="Screenshot_20260722_154057" src="https://github.com/user-attachments/assets/ce1a01c8-1c7f-437d-849f-6ad27dfd1e76" />

This will change the url of the news item, so we need to edit the url in https://lemmy.ml/post/50346212 after merging.